### PR TITLE
macOS compatibility

### DIFF
--- a/src/main/java/com/qouteall/immersive_portals/render/PortalRenderer.java
+++ b/src/main/java/com/qouteall/immersive_portals/render/PortalRenderer.java
@@ -297,19 +297,19 @@ public abstract class PortalRenderer {
     public boolean renderAndGetDoesAnySamplePassed(Runnable renderingFunc) {
         assert (!isQuerying);
         
-        GL15.glBeginQuery(ARBOcclusionQuery2.GL_ANY_SAMPLES_PASSED, idQueryObject);
+        GL15.glBeginQuery(GL15.GL_SAMPLES_PASSED, idQueryObject);
         
         isQuerying = true;
         
         renderingFunc.run();
         
-        GL15.glEndQuery(ARBOcclusionQuery2.GL_ANY_SAMPLES_PASSED);
+        GL15.glEndQuery(GL15.GL_SAMPLES_PASSED);
         
         isQuerying = false;
         
         int result = GL15.glGetQueryObjecti(idQueryObject, GL15.GL_QUERY_RESULT);
         
-        return result != 0;
+        return result > 0;
     }
     
     private int renderAndGetSampleCountPassed(Runnable renderingFunc) {


### PR DESCRIPTION
Turns out `GL_ANY_SAMPLES_PASSED` is unavailable on macOS for whatever reason. Simply switching to `GL_SAMPLES_PASSED` fixed the issue. (I also changed the return comparison from `!=` to `>` because I felt like it was clearer with this method.)