### PR TITLE
Fix rotation bobbing issue

### DIFF
--- a/src/main/java/com/qouteall/immersive_portals/render/TransformationManager.java
+++ b/src/main/java/com/qouteall/immersive_portals/render/TransformationManager.java
@@ -133,6 +133,12 @@ public class TransformationManager {
             player.pitch = getPitchFromViewVector(newViewVector);
             player.prevPitch = player.pitch;
             
+            player.renderYaw = player.yaw;
+            player.renderPitch = player.pitch;
+            
+            player.lastRenderYaw = player.renderYaw;
+            player.lastRenderPitch = player.renderPitch;
+            
             Quaternion newCameraRotation = getCameraRotation(player.pitch, player.yaw);
             
             if (!Helper.isClose(newCameraRotation, visualRotation, 0.001f)) {


### PR DESCRIPTION
Hey,
I fixed a little bug where the hand of the player would bob if the portal rotation and the destination rotation are not equal.
This was fixed by setting the renderYaw and renderPitch, as well as the lastRenderYaw and lastRenderPitch to the yaw of the player to prevent the renderer from interpolating incorrectly.