### PR TITLE
Added "interactable" attribute to portals which can disable the player portal interaction

### DIFF
--- a/src/main/java/com/qouteall/hiding_in_the_bushes/ModMenuConfigEntry.java
+++ b/src/main/java/com/qouteall/hiding_in_the_bushes/ModMenuConfigEntry.java
@@ -77,6 +77,10 @@ public class ModMenuConfigEntry implements ModMenuApi {
                 "imm_ptl.reversible_nether_portal_linking",
                 currConfig.reversibleNetherPortalLinking
             ).setDefaultValue(false).build();
+            BooleanListEntry entryMirrorInteractableThroughPortal = builder.entryBuilder().startBooleanToggle(
+                    "imm_ptl.mirror_interactable_through_portal",
+                    currConfig.mirrorInteractableThroughPortal
+            ).setDefaultValue(true).build();
             StringListListEntry entryDimensionRenderRedirect = builder.entryBuilder().startStrList(
                 "imm_ptl.render_redirect",
                 MyConfig.mapToList(currConfig.dimensionRenderRedirect)
@@ -95,6 +99,7 @@ public class ModMenuConfigEntry implements ModMenuApi {
             category.addEntry(entryMultiThreadedNetherPortalSearching);
             category.addEntry(entryEdgelessSky);
             category.addEntry(entryReversibleNetherPortalLinking);
+            category.addEntry(entryMirrorInteractableThroughPortal);
             category.addEntry(entryDimensionRenderRedirect);
             return builder
                 .setParentScreen(parent)
@@ -113,6 +118,7 @@ public class ModMenuConfigEntry implements ModMenuApi {
                     newConfigObject.multiThreadedNetherPortalSearching = entryMultiThreadedNetherPortalSearching.getValue();
                     newConfigObject.edgelessSky = entryEdgelessSky.getValue();
                     newConfigObject.reversibleNetherPortalLinking = entryReversibleNetherPortalLinking.getValue();
+                    newConfigObject.mirrorInteractableThroughPortal = entryMirrorInteractableThroughPortal.getValue();
                     newConfigObject.dimensionRenderRedirect = MyConfig.listToMap(
                         entryDimensionRenderRedirect.getValue()
                     );

--- a/src/main/java/com/qouteall/hiding_in_the_bushes/MyConfig.java
+++ b/src/main/java/com/qouteall/hiding_in_the_bushes/MyConfig.java
@@ -31,6 +31,7 @@ public class MyConfig {
     public boolean multiThreadedNetherPortalSearching = true;
     public boolean edgelessSky = false;
     public boolean reversibleNetherPortalLinking = false;
+    public boolean mirrorInteractableThroughPortal = true;
     public Map<String, String> dimensionRenderRedirect = defaultRedirectMap;
     
     private static File getGameDir() {
@@ -88,7 +89,7 @@ public class MyConfig {
         Global.netherPortalFindingRadius = portalSearchingRange;
         Global.longerReachInCreative = longerReachInCreative;
         Global.renderYourselfInPortal = renderYourselfInPortal;
-        
+
         if (O_O.isReachEntityAttributesPresent) {
             Global.longerReachInCreative = false;
         }
@@ -100,7 +101,8 @@ public class MyConfig {
         Global.multiThreadedNetherPortalSearching = multiThreadedNetherPortalSearching;
         Global.edgelessSky = edgelessSky;
         Global.reversibleNetherPortalLinking = reversibleNetherPortalLinking;
-        
+        Global.mirrorInteractableThroughPortal = mirrorInteractableThroughPortal;
+
         if (FabricLoader.INSTANCE.getEnvironmentType() == EnvType.CLIENT) {
             RenderDimensionRedirect.updateIdMap(dimensionRenderRedirect);
         }

--- a/src/main/java/com/qouteall/immersive_portals/Global.java
+++ b/src/main/java/com/qouteall/immersive_portals/Global.java
@@ -43,7 +43,9 @@ public class Global {
     public static boolean looseVisibleChunkIteration = true;
     
     public static boolean blameOpenJdk = true;
-    
+
+    public static boolean mirrorInteractableThroughPortal = true;
+
     public static enum RenderMode {
         normal,
         compatibility,

--- a/src/main/java/com/qouteall/immersive_portals/block_manipulation/BlockManipulationClient.java
+++ b/src/main/java/com/qouteall/immersive_portals/block_manipulation/BlockManipulationClient.java
@@ -55,22 +55,24 @@ public class BlockManipulationClient {
         Vec3d cameraPos = client.gameRenderer.getCamera().getPos();
         
         float reachDistance = client.interactionManager.getReachDistance();
-        
+
         MyCommandServer.getPlayerPointingPortalRaw(
             client.player, partialTicks, reachDistance, true
         ).ifPresent(pair -> {
-            double distanceToPortalPointing = pair.getSecond().distanceTo(cameraPos);
-            if (distanceToPortalPointing < getCurrentTargetDistance() + 0.2) {
-                client.crosshairTarget = createMissedHitResult(cameraPos, pair.getSecond());
+            if(pair.getFirst().canInteractThroughPortal()) {
+                double distanceToPortalPointing = pair.getSecond().distanceTo(cameraPos);
+                if(distanceToPortalPointing < getCurrentTargetDistance() + 0.2) {
+                    client.crosshairTarget = createMissedHitResult(cameraPos, pair.getSecond());
 
-                updateTargetedBlockThroughPortal(
-                    cameraPos,
-                    client.player.getRotationVec(partialTicks),
-                    client.player.dimension,
-                    distanceToPortalPointing,
-                    reachDistance,
-                    pair.getFirst()
-                );
+                    updateTargetedBlockThroughPortal(
+                            cameraPos,
+                            client.player.getRotationVec(partialTicks),
+                            client.player.dimension,
+                            distanceToPortalPointing,
+                            reachDistance,
+                            pair.getFirst()
+                    );
+                }
             }
         });
     }
@@ -188,7 +190,7 @@ public class BlockManipulationClient {
         }
         
     }
-    
+
     public static void myHandleBlockBreaking(boolean isKeyPressed) {
 //        if (remoteHitResult == null) {
 //            return;

--- a/src/main/java/com/qouteall/immersive_portals/block_manipulation/BlockManipulationClient.java
+++ b/src/main/java/com/qouteall/immersive_portals/block_manipulation/BlockManipulationClient.java
@@ -59,7 +59,7 @@ public class BlockManipulationClient {
         MyCommandServer.getPlayerPointingPortalRaw(
             client.player, partialTicks, reachDistance, true
         ).ifPresent(pair -> {
-            if(pair.getFirst().canInteractThroughPortal()) {
+            if(pair.getFirst().isInteractable()) {
                 double distanceToPortalPointing = pair.getSecond().distanceTo(cameraPos);
                 if(distanceToPortalPointing < getCurrentTargetDistance() + 0.2) {
                     client.crosshairTarget = createMissedHitResult(cameraPos, pair.getSecond());

--- a/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
+++ b/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
@@ -16,14 +16,19 @@ public class Mirror extends Portal {
     public void tick() {
         super.tick();
         teleportable = false;
-        interactable = Global.mirrorInteractableThroughPortal;
     }
-    
+
+    @Override
+    public boolean isInteractable()
+    {
+        return Global.mirrorInteractableThroughPortal && super.isInteractable();
+    }
+
     @Override
     public Vec3d getContentDirection() {
         return getNormal();
     }
-    
+
     @Override
     public Vec3d transformPoint(Vec3d pos) {
         Vec3d localPos = pos.subtract(getPos());

--- a/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
+++ b/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
@@ -15,7 +15,6 @@ public class Mirror extends Portal {
     public void tick() {
         super.tick();
         teleportable = false;
-        interactable = false;
     }
     
     @Override

--- a/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
+++ b/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
@@ -15,6 +15,7 @@ public class Mirror extends Portal {
     public void tick() {
         super.tick();
         teleportable = false;
+        interactable = false;
     }
     
     @Override

--- a/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
+++ b/src/main/java/com/qouteall/immersive_portals/portal/Mirror.java
@@ -1,5 +1,6 @@
 package com.qouteall.immersive_portals.portal;
 
+import com.qouteall.immersive_portals.Global;
 import net.minecraft.entity.EntityType;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -15,6 +16,7 @@ public class Mirror extends Portal {
     public void tick() {
         super.tick();
         teleportable = false;
+        interactable = Global.mirrorInteractableThroughPortal;
     }
     
     @Override

--- a/src/main/java/com/qouteall/immersive_portals/portal/Portal.java
+++ b/src/main/java/com/qouteall/immersive_portals/portal/Portal.java
@@ -49,7 +49,9 @@ public class Portal extends Entity {
     public Quaternion rotation;
     
     public double motionAffinity = 0;
-    
+
+    public boolean interactable = true;
+
     public static final SignalArged<Portal> clientPortalTickSignal = new SignalArged<>();
     public static final SignalArged<Portal> serverPortalTickSignal = new SignalArged<>();
     
@@ -118,6 +120,9 @@ public class Portal extends Entity {
         else {
             motionAffinity = 0;
         }
+        if(compoundTag.contains("interactable")) {
+            interactable = compoundTag.getBoolean("interactable");
+        }
     }
     
     @Override
@@ -153,6 +158,7 @@ public class Portal extends Entity {
             compoundTag.putDouble("rotationD", rotation.getD());
         }
         compoundTag.putDouble("motionAffinity", motionAffinity);
+        compoundTag.putBoolean("interactable", interactable);
     }
     
     public boolean isCullable() {
@@ -165,7 +171,11 @@ public class Portal extends Entity {
     public boolean isTeleportable() {
         return teleportable;
     }
-    
+
+    public boolean canInteractThroughPortal() {
+        return interactable;
+    }
+
     public void updateCache() {
         boundingBoxCache = null;
         normal = null;

--- a/src/main/java/com/qouteall/immersive_portals/portal/Portal.java
+++ b/src/main/java/com/qouteall/immersive_portals/portal/Portal.java
@@ -50,7 +50,7 @@ public class Portal extends Entity {
     
     public double motionAffinity = 0;
 
-    public boolean interactable = true;
+    private boolean interactable = true;
 
     public static final SignalArged<Portal> clientPortalTickSignal = new SignalArged<>();
     public static final SignalArged<Portal> serverPortalTickSignal = new SignalArged<>();
@@ -172,8 +172,22 @@ public class Portal extends Entity {
         return teleportable;
     }
 
-    public boolean canInteractThroughPortal() {
+
+    /**
+     * Determines whether the player should be able to reach through the portal or not.
+     * Can be overridden by a sub class.
+     * @return the interactability of the portal
+     */
+    public boolean isInteractable() {
         return interactable;
+    }
+
+    /**
+     * Changes the reach-through behavior of the portal.
+     * @param interactable the interactability of the portal
+     */
+    public void setInteractable(boolean interactable) {
+        this.interactable = interactable;
     }
 
     public void updateCache() {

--- a/src/main/resources/assets/immersive_portals/lang/en_us.json
+++ b/src/main/resources/assets/immersive_portals/lang/en_us.json
@@ -30,5 +30,6 @@
   "imm_ptl.add_dimension": "Add Dimension",
   "imm_ptl.remove_dimension": "Remove Dimension",
   "imm_ptl.confirm_select_dimension": "Confirm",
-  "imm_ptl.select_dimension": "Select a Dimension"
+  "imm_ptl.select_dimension": "Select a Dimension",
+  "imm_ptl.mirror_interactable_through_portal": "Mirrors can be reached through"
 }


### PR DESCRIPTION
Hi,
I added this feature especially for the "look-through" portals, which imo shouldn't feature the custom manipulation through the portal, so I added a boolean field which can prevent this and implemented it in the mirror class. No other portal is affected :)