### PR TITLE
Don't assume world implementation

### DIFF
--- a/src/main/java/com/qouteall/immersive_portals/CHelper.java
+++ b/src/main/java/com/qouteall/immersive_portals/CHelper.java
@@ -13,10 +13,10 @@ import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.network.PlayerListEntry;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
-import net.minecraft.world.dimension.DimensionType;
 import org.lwjgl.opengl.GL11;
 
 import java.util.Arrays;
@@ -57,7 +57,12 @@ public class CHelper {
     }
     
     public static List<GlobalTrackedPortal> getClientGlobalPortal(World world) {
-        return ((IEClientWorld) world).getGlobalPortals();
+        if (world instanceof ClientWorld) {
+            return ((IEClientWorld) world).getGlobalPortals();
+        }
+        else {
+            return null;
+        }
     }
     
     public static Stream<Portal> getClientNearbyPortals(double range) {

--- a/src/main/java/com/qouteall/immersive_portals/McHelper.java
+++ b/src/main/java/com/qouteall/immersive_portals/McHelper.java
@@ -16,6 +16,7 @@ import com.qouteall.immersive_portals.portal.global_portals.GlobalTrackedPortal;
 import com.qouteall.immersive_portals.render.CrossPortalEntityRenderer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.MessageType;
@@ -290,11 +291,14 @@ public class McHelper {
     
     public static List<GlobalTrackedPortal> getGlobalPortals(World world) {
         List<GlobalTrackedPortal> result;
-        if (world.isClient) {
+        if (world instanceof ClientWorld) {
             result = CHelper.getClientGlobalPortal(world);
         }
-        else {
+        else if (world instanceof ServerWorld) {
             result = GlobalPortalStorage.get(((ServerWorld) world)).data;
+        }
+        else {
+            result = null;
         }
         return result != null ? result : Collections.emptyList();
     }

--- a/src/main/java/com/qouteall/immersive_portals/McHelper.java
+++ b/src/main/java/com/qouteall/immersive_portals/McHelper.java
@@ -16,11 +16,7 @@ import com.qouteall.immersive_portals.portal.global_portals.GlobalTrackedPortal;
 import com.qouteall.immersive_portals.render.CrossPortalEntityRenderer;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.util.math.MatrixStack;
-import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.network.MessageType;
-import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ChunkHolder;
@@ -34,11 +30,9 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Box;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.util.registry.Registry;
 import net.minecraft.util.registry.RegistryKey;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.WorldChunk;
-import net.minecraft.world.dimension.DimensionType;
 import org.lwjgl.opengl.GL11;
 
 import java.lang.ref.WeakReference;
@@ -46,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.IntPredicate;
@@ -291,7 +284,7 @@ public class McHelper {
     
     public static List<GlobalTrackedPortal> getGlobalPortals(World world) {
         List<GlobalTrackedPortal> result;
-        if (world instanceof ClientWorld) {
+        if (world.isClient()) {
             result = CHelper.getClientGlobalPortal(world);
         }
         else if (world instanceof ServerWorld) {


### PR DESCRIPTION
Don't assume the world implementation is ServerWorld/ClientWorld just because of the `isClient` flag.

Fixes a crash with [Lacrimis][1]: https://pastebin.com/GYzH4EEj

(Lacrimis has a [custom World implementation][2] it uses as a dummy to render entities without an actual world)

[1]: https://www.curseforge.com/minecraft/mc-mods/lacrimis
[2]: https://github.com/2xsaiko/modfest-1.16/blob/master/src/main/java/modfest/lacrimis/client/cardgen/DummyWorld.java