### PR TITLE
disable lithium's conflicting mixin

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -40,7 +40,10 @@
   "custom": {
     "fabric-renderer-indigo:force_compatibility": true,
     "mm:early_risers": [
-    ]
+    ],
+    "lithium:options": {
+    	"mixin.world.player_chunk_tick": false
+    }
   },
   "accessWidener" : "imm_ptl_peripheral.accesswidener"
 }


### PR DESCRIPTION
Fixes #330
Lithium has a way for other mods to automatically disable conflicting mixins, so that users don't have to do it manually.