### PR TITLE
Fix for Bits And Chisels

### DIFF
--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/chunk_sync/MixinCustomPayloadS2CPacket.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/chunk_sync/MixinCustomPayloadS2CPacket.java
@@ -4,12 +4,17 @@ import com.qouteall.immersive_portals.Helper;
 import com.qouteall.immersive_portals.my_util.LimitedLogger;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(CustomPayloadS2CPacket.class)
 public class MixinCustomPayloadS2CPacket {
+    @Shadow private Identifier channel;
+    @Shadow private PacketByteBuf data;
     private static final LimitedLogger limitedLogger = new LimitedLogger(10);
     
     @Redirect(
@@ -28,5 +33,22 @@ public class MixinCustomPayloadS2CPacket {
             });
         }
         return 0;
+    }
+
+    /**
+     * @author cozyGalvinism
+     * @reason Allow for bigger packets to be sent
+     */
+    @Overwrite()
+    public void read(PacketByteBuf packetByteBuf) {
+        this.channel = packetByteBuf.readIdentifier();
+        int i = packetByteBuf.readableBytes();
+        if(i < 0 || i > 1048576) {
+            limitedLogger.invoke(() -> {
+                Helper.err("Received very big packet " + i);
+                new Throwable().printStackTrace();
+            });
+        }
+        this.data = new PacketByteBuf(packetByteBuf.readBytes(i));
     }
 }


### PR DESCRIPTION
This should fix #474 and #702 . This is an addition to the CustomPayloadS2CPacket mixin, which overwrites the default behaviour of `read()` to allow packets bigger than 1048576 bytes. I don't know if overwriting is the best option here, but I have next to no experience with Fabric mods, let alone mixins. My previous goal was to just overwrite the part containing the if-statement, but I don't know if that's possible or how to do that. Instead of throwing an exception, I simply log the stacktrace.