### PR TITLE
naive dimThread compatibility fix

### DIFF
--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/chunk_loading/EntitySync.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/chunk_loading/EntitySync.java
@@ -60,7 +60,7 @@ public class EntitySync {
             Int2ObjectMap<ThreadedAnvilChunkStorage.EntityTracker> entityTrackerMap =
                 ((IEThreadedAnvilChunkStorage) storage).getEntityTrackerMap();
             
-            CommonNetwork.withForceRedirect(world.getRegistryKey(), () -> {
+            CommonNetwork.withForceRedirect(world, () -> {
                 for (ThreadedAnvilChunkStorage.EntityTracker tracker : entityTrackerMap.values()) {
                     ((IEEntityTracker) tracker).tickEntry();
                     

--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/ducks/IMutableThread.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/ducks/IMutableThread.java
@@ -1,0 +1,5 @@
+package com.qouteall.immersive_portals.ducks;
+
+public interface IMutableThread {
+	Thread getThread();
+}

--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/MixinServerWorld.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/MixinServerWorld.java
@@ -59,7 +59,7 @@ public abstract class MixinServerWorld implements IEServerWorld {
     private void redirectSendToAll(PlayerManager playerManager, Packet<?> packet) {
         final ServerWorld this_ = (ServerWorld) (Object) this;
         CommonNetwork.withForceRedirect(
-            this_.getRegistryKey(),
+            this_,
             () -> {
                 playerManager.sendToAll(packet);
             }

--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/entity_sync/MixinEntityTracker.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/entity_sync/MixinEntityTracker.java
@@ -138,7 +138,7 @@ public abstract class MixinEntityTracker implements IEEntityTracker {
             
             if (shouldTrack && this.playersTracking.add(player)) {
                 CommonNetwork.withForceRedirect(
-                    entity.world.getRegistryKey(),
+                    entity.world,
                     () -> {
                         this.entry.startTracking(player);
                     }
@@ -147,7 +147,7 @@ public abstract class MixinEntityTracker implements IEEntityTracker {
         }
         else if (this.playersTracking.remove(player)) {
             CommonNetwork.withForceRedirect(
-                entity.world.getRegistryKey(),
+                entity.world,
                 () -> {
                     this.entry.stopTracking(player);
                 }

--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/entity_sync/MixinThreadedAnvilChunkStorage_E.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/mixin/common/entity_sync/MixinThreadedAnvilChunkStorage_E.java
@@ -95,7 +95,7 @@ public abstract class MixinThreadedAnvilChunkStorage_E implements IEThreadedAnvi
         }
         
         CommonNetwork.withForceRedirect(
-            world.getRegistryKey(),
+            world,
             () -> {
                 for (Entity entity : attachedEntityList) {
                     player.networkHandler.sendPacket(new EntityAttachS2CPacket(

--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/network/CommonNetwork.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/network/CommonNetwork.java
@@ -2,6 +2,7 @@ package com.qouteall.immersive_portals.network;
 
 import com.qouteall.hiding_in_the_bushes.MyNetwork;
 import com.qouteall.immersive_portals.McHelper;
+import com.qouteall.immersive_portals.ducks.IMutableThread;
 import me.jellysquid.mods.sodium.mixin.features.world_ticking.MixinClientWorld;
 import net.minecraft.network.Packet;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
@@ -58,9 +59,5 @@ public class CommonNetwork {
                 )
             );
         }
-    }
-
-    public interface IMutableThread {
-        Thread getThread();
     }
 }

--- a/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/network/CommonNetwork.java
+++ b/imm_ptl_core/src/main/java/com/qouteall/immersive_portals/network/CommonNetwork.java
@@ -2,6 +2,7 @@ package com.qouteall.immersive_portals.network;
 
 import com.qouteall.hiding_in_the_bushes.MyNetwork;
 import com.qouteall.immersive_portals.McHelper;
+import me.jellysquid.mods.sodium.mixin.features.world_ticking.MixinClientWorld;
 import net.minecraft.network.Packet;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.util.registry.RegistryKey;
@@ -16,14 +17,13 @@ public class CommonNetwork {
     @Nullable
     public static RegistryKey<World> forceRedirect = null;
     
-    public static void withForceRedirect(RegistryKey<World> dimension, Runnable func) {
+    public static void withForceRedirect(World dimension, Runnable func) {
         Validate.isTrue(
-            McHelper.getServer().getThread() == Thread.currentThread(),
+            ((IMutableThread)dimension).getThread() == Thread.currentThread(),
             "Maybe a mod is trying to add entity in a non-server thread. This is probably not IP's issue"
         );
-        
         RegistryKey<World> oldForceRedirect = forceRedirect;
-        forceRedirect = dimension;
+        forceRedirect = dimension.getRegistryKey();
         try {
             func.run();
         }
@@ -58,5 +58,9 @@ public class CommonNetwork {
                 )
             );
         }
+    }
+
+    public interface IMutableThread {
+        Thread getThread();
     }
 }

--- a/src/main/java/com/qouteall/hiding_in_the_bushes/mixin/WorldMixin.java
+++ b/src/main/java/com/qouteall/hiding_in_the_bushes/mixin/WorldMixin.java
@@ -1,13 +1,13 @@
-package com.qouteall.hiding_in_the_bushes.mixin.alternate_dimension;
+package com.qouteall.hiding_in_the_bushes.mixin;
 
-import com.qouteall.immersive_portals.network.CommonNetwork;
+import com.qouteall.immersive_portals.ducks.IMutableThread;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(World.class)
-public class WorldMixin implements CommonNetwork.IMutableThread {
+public class WorldMixin implements IMutableThread {
 
 	@Shadow @Final private Thread thread;
 

--- a/src/main/java/com/qouteall/hiding_in_the_bushes/mixin/alternate_dimension/WorldMixin.java
+++ b/src/main/java/com/qouteall/hiding_in_the_bushes/mixin/alternate_dimension/WorldMixin.java
@@ -1,0 +1,19 @@
+package com.qouteall.hiding_in_the_bushes.mixin.alternate_dimension;
+
+import com.qouteall.immersive_portals.network.CommonNetwork;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(World.class)
+public class WorldMixin implements CommonNetwork.IMutableThread {
+
+	@Shadow @Final private Thread thread;
+
+	@Override
+	public Thread getThread() {
+		return this.thread;
+	}
+}
+

--- a/src/main/resources/imm_ptl_peripheral_fabric.mixins.json
+++ b/src/main/resources/imm_ptl_peripheral_fabric.mixins.json
@@ -4,7 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "alternate_dimension.MixinMobSpawnerLogic",
-    "alternate_dimension.WorldMixin",
+    "WorldMixin",
     "block_manipulation.MixinItem",
     "block_manipulation.MixinServerPlayerInteractionManager",
     "block_manipulation.MixinServerPlayNetworkHandler_B"

--- a/src/main/resources/imm_ptl_peripheral_fabric.mixins.json
+++ b/src/main/resources/imm_ptl_peripheral_fabric.mixins.json
@@ -4,6 +4,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "alternate_dimension.MixinMobSpawnerLogic",
+    "alternate_dimension.WorldMixin",
     "block_manipulation.MixinItem",
     "block_manipulation.MixinServerPlayerInteractionManager",
     "block_manipulation.MixinServerPlayNetworkHandler_B"


### PR DESCRIPTION
this fixes
https://github.com/WearBlackAllDay/DimensionalThreading/issues/25

this prevents the (intended) crash by adjusting the according check, without affecting other cases.

this does NOT however fix rare crashes caused by racing; i will implement a fix for that on my end within the next days.

for now it makes both mods work fine together, albeit be it not safely.