### PR TITLE
Use alternative RegistryOps constructor call to fix datapack errors. #787

### DIFF
--- a/q_misc_util/src/main/java/qouteall/q_misc_util/mixin/MixinMinecraftServer_Misc.java
+++ b/q_misc_util/src/main/java/qouteall/q_misc_util/mixin/MixinMinecraftServer_Misc.java
@@ -59,7 +59,7 @@ public abstract class MixinMinecraftServer_Misc {
                 " This may cause other issues"
         );
         RegistryOps<JsonElement> registryOps =
-            RegistryOps.of(JsonOps.INSTANCE, resourceManager.getResourceManager(), registryTracker);
+            RegistryOps.method_36574(JsonOps.INSTANCE, resourceManager.getResourceManager(), registryTracker);
         
         DynamicRegistryManager.load(registryTracker, registryOps);
     }

--- a/src/main/java/qouteall/imm_ptl/peripheral/altius_world/WorldCreationDimensionHelper.java
+++ b/src/main/java/qouteall/imm_ptl/peripheral/altius_world/WorldCreationDimensionHelper.java
@@ -64,7 +64,7 @@ public class WorldCreationDimensionHelper {
         RegistryReadingOps<JsonElement> registryReadingOps =
             RegistryReadingOps.of(JsonOps.INSTANCE, registryTracker);
         RegistryOps<JsonElement> registryOps =
-            RegistryOps.of(JsonOps.INSTANCE, (ResourceManager) resourceManager, registryTracker);
+            RegistryOps.method_36574(JsonOps.INSTANCE, (ResourceManager) resourceManager, registryTracker);
         
         DynamicRegistryManager.load(registryTracker, registryOps);
         


### PR DESCRIPTION
RegistryOps constructor call should use (the poorly named) `method_36574` so that biomes from datapacks get loaded instead of vanilla biomes. This allows mods that add biome features using Fabric's biome API to have them properly located/generated.