### PR TITLE
Add option to silence portal noise

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/IPGlobal.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/IPGlobal.java
@@ -99,6 +99,8 @@ public class IPGlobal {
     public static boolean enableDatapackPortalGen = true;
     
     public static boolean enableCrossPortalView = true;
+
+    public static boolean silencePortalNoise = true;
     
     public static enum RenderMode {
         normal,

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/IPGlobal.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/IPGlobal.java
@@ -100,7 +100,7 @@ public class IPGlobal {
     
     public static boolean enableCrossPortalView = true;
 
-    public static boolean silencePortalNoise = true;
+    public static boolean enableNetherPortalNoise = false;
     
     public static enum RenderMode {
         normal,

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/IPConfig.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/IPConfig.java
@@ -47,7 +47,7 @@ public class IPConfig {
     public boolean enableDatapackPortalGen = true;
     public boolean enableDedicatedServerEarlyReload = true;
     public boolean enableCrossPortalView = true;
-    public boolean silencePortalNoise = true;
+    public boolean enableNetherPortalNoise = false;
     public Map<String, String> dimensionRenderRedirect = defaultRedirectMap;
     public IPGlobal.NetherPortalMode netherPortalMode = IPGlobal.NetherPortalMode.normal;
     public IPGlobal.EndPortalMode endPortalMode = IPGlobal.EndPortalMode.normal;
@@ -151,7 +151,7 @@ public class IPConfig {
         IPGlobal.enableSharedBlockMeshBuffers = sharedBlockMeshBufferOptimization;
         IPGlobal.enableDatapackPortalGen = enableDatapackPortalGen;
         IPGlobal.enableCrossPortalView = enableCrossPortalView;
-        IPGlobal.silencePortalNoise = silencePortalNoise;
+        IPGlobal.enableNetherPortalNoise = enableNetherPortalNoise;
 //        IPGlobal.enableServerCollision = enableServerCollision;
         
         DimensionMisc.enableDedicatedServerEarlyReload = enableDedicatedServerEarlyReload;

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/IPConfig.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/IPConfig.java
@@ -47,6 +47,7 @@ public class IPConfig {
     public boolean enableDatapackPortalGen = true;
     public boolean enableDedicatedServerEarlyReload = true;
     public boolean enableCrossPortalView = true;
+    public boolean silencePortalNoise = true;
     public Map<String, String> dimensionRenderRedirect = defaultRedirectMap;
     public IPGlobal.NetherPortalMode netherPortalMode = IPGlobal.NetherPortalMode.normal;
     public IPGlobal.EndPortalMode endPortalMode = IPGlobal.EndPortalMode.normal;
@@ -150,6 +151,7 @@ public class IPConfig {
         IPGlobal.enableSharedBlockMeshBuffers = sharedBlockMeshBufferOptimization;
         IPGlobal.enableDatapackPortalGen = enableDatapackPortalGen;
         IPGlobal.enableCrossPortalView = enableCrossPortalView;
+        IPGlobal.silencePortalNoise = silencePortalNoise;
 //        IPGlobal.enableServerCollision = enableServerCollision;
         
         DimensionMisc.enableDedicatedServerEarlyReload = enableDedicatedServerEarlyReload;

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/nether_portal/NetherPortalEntity.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/nether_portal/NetherPortalEntity.java
@@ -63,7 +63,7 @@ public class NetherPortalEntity extends BreakablePortalEntity {
             }
         }
         
-        if (!IPGlobal.silencePortalNoise && random.nextInt(800) == 0) {
+        if (IPGlobal.enableNetherPortalNoise && random.nextInt(800) == 0) {
             world.playSound(
                 getX(),
                 getY(),

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/nether_portal/NetherPortalEntity.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/portal/nether_portal/NetherPortalEntity.java
@@ -1,5 +1,6 @@
 package qouteall.imm_ptl.core.portal.nether_portal;
 
+import qouteall.imm_ptl.core.IPGlobal;
 import qouteall.imm_ptl.core.platform_specific.O_O;
 import qouteall.imm_ptl.core.portal.PortalPlaceholderBlock;
 import net.fabricmc.api.EnvType;
@@ -62,7 +63,7 @@ public class NetherPortalEntity extends BreakablePortalEntity {
             }
         }
         
-        if (random.nextInt(800) == 0) {
+        if (!IPGlobal.silencePortalNoise && random.nextInt(800) == 0) {
             world.playSound(
                 getX(),
                 getY(),


### PR DESCRIPTION
### Change
Added a config option to silence the ambient nether portal sound.  

I feel that the stock portal sound doesn't quite fit the feel for an immersive portal.  It goes well with the stock mysterious swirling purple aesthetic, but tends to cover up the immersion and more subtle ambient noises that this mod enables. 

I set the default to silence = true for my testing, but the default value should be decided by the author. 