### PR TITLE
Partial update to 1.18.0, also updates Pehkui

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ allprojects {
         }
         modCompileOnly "com.github.TerraformersMC:ModMenu:${modmenu_version}"
 
-        modCompileOnly('com.github.Virtuoel:Pehkui:fabric~1.14.4-1.17-SNAPSHOT') {
+        modCompileOnly('com.github.Virtuoel:Pehkui:fabric~1.14.4-1.x.x-SNAPSHOT') {
             transitive = false
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,9 +14,9 @@ modmenu_version=1.16.8
 cloth_config_version=5.0.34
 
 
-minecraft_version=1.18-pre6
-yarn_mappings=1.18-pre6+build.1
+minecraft_version=1.18
+yarn_mappings=1.18+build.1
 loader_version=0.12.5
 
 #Fabric api
-fabric_version=0.42.9+1.18
+fabric_version=0.43.1+1.18

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinChunkRendererRegionBuilder.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinChunkRendererRegionBuilder.java
@@ -1,6 +1,7 @@
 package qouteall.imm_ptl.core.mixin.client.render;
 
 import net.minecraft.client.render.chunk.ChunkRendererRegion;
+import net.minecraft.client.render.chunk.ChunkRendererRegionBuilder;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -8,15 +9,15 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(ChunkRendererRegion.class)
-public class MixinChunkRendererRegion {
+@Mixin(ChunkRendererRegionBuilder.class)
+public class MixinChunkRendererRegionBuilder {
     //will this avoid that random crash?
     @Inject(
-        method = "Lnet/minecraft/client/render/chunk/ChunkRendererRegion;create(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;I)Lnet/minecraft/client/render/chunk/ChunkRendererRegion;",
+        method = "Lnet/minecraft/client/render/chunk/ChunkRendererRegionBuilder;build(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/BlockPos;I)Lnet/minecraft/client/render/chunk/ChunkRendererRegion;",
         at = @At("HEAD"),
         cancellable = true
     )
-    private static void onCreate(
+    private void onBuild(
         World worldIn,
         BlockPos from,
         BlockPos to,

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinWorldRenderer.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinWorldRenderer.java
@@ -759,7 +759,7 @@ public abstract class MixinWorldRenderer implements IEWorldRenderer {
     
     @Override
     public void portal_setChunkInfoList(ObjectArrayList<WorldRenderer.ChunkInfo> arg) {
-    	chunkInfos = arg;
+        chunkInfos = arg;
     }
     
     @Override

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinWorldRenderer.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinWorldRenderer.java
@@ -120,7 +120,7 @@ public abstract class MixinWorldRenderer implements IEWorldRenderer {
     @Mutable
     @Shadow
     @Final
-    private ObjectArrayList<WorldRenderer.ChunkInfo> field_34807;
+    private ObjectArrayList<WorldRenderer.ChunkInfo> chunkInfos;
     
     // important rendering hooks
     @Inject(
@@ -254,7 +254,7 @@ public abstract class MixinWorldRenderer implements IEWorldRenderer {
                 world, ((MyBuiltChunkStorage) chunks),
                 camera,
                 new Frustum(frustum).method_38557(8),
-                field_34807
+                chunkInfos
             );
             world.getProfiler().pop();
             
@@ -284,7 +284,7 @@ public abstract class MixinWorldRenderer implements IEWorldRenderer {
                     world, ((MyBuiltChunkStorage) chunks),
                     camera,
                     new Frustum(frustum).method_38557(8),
-                    field_34807
+                    chunkInfos
                 );
                 world.getProfiler().pop();
             }
@@ -759,11 +759,11 @@ public abstract class MixinWorldRenderer implements IEWorldRenderer {
     
     @Override
     public void portal_setChunkInfoList(ObjectArrayList<WorldRenderer.ChunkInfo> arg) {
-        field_34807 = arg;
+    	chunkInfos = arg;
     }
     
     @Override
     public ObjectArrayList<WorldRenderer.ChunkInfo> portal_getChunkInfoList() {
-        return field_34807;
+        return chunkInfos;
     }
 }

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/PehkuiInterfaceInitializer.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/PehkuiInterfaceInitializer.java
@@ -15,7 +15,7 @@ import net.minecraft.util.Util;
 import net.minecraft.util.math.Vec3d;
 import org.apache.commons.lang3.Validate;
 import virtuoel.pehkui.api.ScaleData;
-import virtuoel.pehkui.api.ScaleType;
+import virtuoel.pehkui.api.ScaleTypes;
 
 public class PehkuiInterfaceInitializer {
     
@@ -26,7 +26,7 @@ public class PehkuiInterfaceInitializer {
         
         PehkuiInterface.onServerEntityTeleported = PehkuiInterfaceInitializer::onEntityTeleportedServer;
         
-        PehkuiInterface.getScale = e -> ScaleType.BASE.getScaleData(e).getScale();
+        PehkuiInterface.getScale = e -> ScaleTypes.BASE.getScaleData(e).getScale();
     }
     
     @Environment(EnvType.CLIENT)
@@ -42,7 +42,7 @@ public class PehkuiInterfaceInitializer {
             
             Validate.notNull(player);
             
-            ScaleData scaleData = ScaleType.BASE.getScaleData(player);
+            ScaleData scaleData = ScaleTypes.BASE.getScaleData(player);
             Vec3d eyePos = McHelper.getEyePos(player);
             Vec3d lastTickEyePos = McHelper.getLastTickEyePos(player);
             
@@ -80,7 +80,7 @@ public class PehkuiInterfaceInitializer {
             if (!portal.teleportChangesScale) {
                 return;
             }
-            ScaleData scaleData = ScaleType.BASE.getScaleData(entity);
+            ScaleData scaleData = ScaleTypes.BASE.getScaleData(entity);
             Vec3d eyePos = McHelper.getEyePos(entity);
             Vec3d lastTickEyePos = McHelper.getLastTickEyePos(entity);
             

--- a/imm_ptl_core/src/main/resources/imm_ptl.mixins.json
+++ b/imm_ptl_core/src/main/resources/imm_ptl.mixins.json
@@ -74,7 +74,7 @@
     "client.render.MixinBlockEntityRenderDispatcher",
     "client.render.MixinBuiltChunk",
     "client.render.MixinCamera",
-    "client.render.MixinChunkRendererRegion",
+    "client.render.MixinChunkRendererRegionBuilder",
     "client.render.MixinEntityRenderDispatcher",
     "client.render.MixinGameRenderer",
     "client.render.MixinGlStateManager",

--- a/src/main/java/qouteall/imm_ptl/peripheral/alternate_dimension/AlternateDimensions.java
+++ b/src/main/java/qouteall/imm_ptl/peripheral/alternate_dimension/AlternateDimensions.java
@@ -258,7 +258,7 @@ public class AlternateDimensions {
                 new SlideConfig(-23.4375, 64, -46),
                 new SlideConfig(-0.234375, 7, 1),
                 2, 1, bl2, false, false,
-                VanillaTerrainParametersCreator.createIslandParameters()
+                VanillaTerrainParametersCreator.createEndParameters()
             ),
             defaultBlock, defaultFluid, VanillaSurfaceRules.createOverworldSurfaceRule(),
             0, bl, false, false, false, false,


### PR DESCRIPTION
This PR updates IP to MC 1.18 from pre6 and updates the Pehkui version to 3.0.0, removing references to its deprecated API.

With this, I'm able to launch the built IP jar + Fabric API 0.43.1 + Pehkui 3.0.0 out of dev in 1.18, load into a world without crashes, and portal scaling appears to still work.

I say "partial update" because I initially planned to just update Pehkui with this PR, so I haven't really tested this with the rest of vanilla's changes since pre6 too thoroughly as I don't know all the intricacies of IP's mixins. Also haven't done any investigation into what would be needed in terms of updating Sodium or Iris compatibility.
