### PR TITLE
Fix blocks placed in both worlds for client

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/IPMcHelper.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/IPMcHelper.java
@@ -114,27 +114,6 @@ public class IPMcHelper {
     }
     
     /**
-     * @see #withSwitchedContext(World, Supplier)
-     */
-    @Environment(EnvType.CLIENT)
-    public static <T> T withSwitchedContextClient(ClientWorld world, Supplier<T> func) {
-        Helper.SimpleBox<T> box = new Helper.SimpleBox<>(null);
-        IPCommonNetworkClient.withSwitchedWorld(world, () -> {
-            box.obj = func.get();
-        });
-        return box.obj;
-    }
-    
-    /**
-     * @see #withSwitchedContext(World, Supplier)
-     */
-    @SuppressWarnings("unused")
-    private static <T> T withSwitchedContextServer(ServerWorld world, Supplier<T> func) {
-        // lol
-        return func.get();
-    }
-    
-    /**
      * Execute {@code func} with the world being set to {@code world}, hopefully bypassing any issues that may be
      * related to mutating a world that is not currently set as the current world.
      * <p>
@@ -145,12 +124,12 @@ public class IPMcHelper {
      * @param <T>   The return type of {@code func}.
      * @return Whatever {@code func} returned.
      */
-    static <T> T withSwitchedContext(World world, Supplier<T> func) {
+    public static <T> T withSwitchedContext(World world, Supplier<T> func) {
         if (world.isClient) {
-            return withSwitchedContextClient((ClientWorld) world, func);
+            return IPCommonNetworkClient.withSwitchedWorld((ClientWorld) world, func);
         }
         else {
-            return withSwitchedContextServer((ServerWorld) world, func);
+            return func.get();
         }
     }
     

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/block_manipulation/BlockManipulationClient.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/block_manipulation/BlockManipulationClient.java
@@ -220,7 +220,7 @@ public class BlockManipulationClient {
     ) {
         ClientWorld targetWorld = ClientWorldLoader.getWorld(remotePointedDim);
         
-        return IPMcHelper.withSwitchedContextClient(
+        return IPMcHelper.withSwitchedContext(
             targetWorld,
             () -> {
                 isContextSwitched = true;
@@ -248,7 +248,7 @@ public class BlockManipulationClient {
             return;
         }
         
-        IPCommonNetworkClient.withSwitchedWorld(
+        IPMcHelper.withSwitchedContext(
             targetWorld,
             () -> {
                 isContextSwitched = true;
@@ -257,6 +257,7 @@ public class BlockManipulationClient {
                         blockPos,
                         ((BlockHitResult) remoteHitResult).getSide()
                     );
+                    return null; // Must return null for "void" supplier
                 }
                 finally {
                     isContextSwitched = false;
@@ -329,7 +330,7 @@ public class BlockManipulationClient {
 //            return null;
 //        }
         
-        return IPMcHelper.withSwitchedContextClient(
+        return IPMcHelper.withSwitchedContext(
             targetWorld,
             () -> {
                 isContextSwitched = true;


### PR DESCRIPTION
### Changes:
In recently released 1.1.3, blocks placed through a portal would be placed in both dimensions
Before Place:
![2021-12-15_22 28 11](https://user-images.githubusercontent.com/6741766/146309122-29a2285f-dc87-44df-82df-083966a89062.png)
After Place:
![2021-12-15_22 28 12](https://user-images.githubusercontent.com/6741766/146309144-d5056340-d0b0-4603-96b2-63289e7afa2c.png)

Issue was introduced in commit [e71acb2](https://github.com/qouteall/ImmersivePortalsMod/commit/e71acb2af1490e828c0cafddd7ed8441c5dbbbc8). `client.player.world` Is no longer being changed when the block is placed.  Block in over-world only exists client side in the above example.

I also made a small refactor to `IPMcHelper.java` and `IPCommonNetworkClient.java` context switch methods to remove the need to store results from a runnable in a static `SimpleBox<T>` by using Suppliers and making an overload for existing methods that still need to use `Runnables`.