### PR TITLE
Pehkui compat fixes & cleanup

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/PehkuiInterface.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/PehkuiInterface.java
@@ -7,9 +7,6 @@ import net.minecraft.entity.Entity;
 import net.minecraft.text.TranslatableText;
 import qouteall.imm_ptl.core.portal.Portal;
 
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-
 public class PehkuiInterface {
     
     public static class Invoker {
@@ -30,15 +27,15 @@ public class PehkuiInterface {
         }
         
         public float getBaseScale(Entity entity, float tickDelta) {
-            return getBaseScale.apply(entity, tickDelta);
+            return 1.0f;
         }
         
         public void setBaseScale(Entity entity, float scale) {
-            setBaseScale.accept(entity, scale);
+            
         }
         
         public float computeThirdPersonScale(Entity entity, float tickDelta) {
-            return computeThirdPersonScale.apply(entity, tickDelta);
+            return 1.0f;
         }
         
         public float computeBlockReachScale(Entity entity) {
@@ -46,7 +43,7 @@ public class PehkuiInterface {
         }
         
         public float computeBlockReachScale(Entity entity, float tickDelta) {
-            return computeBlockReachScale.apply(entity, tickDelta);
+            return 1.0f;
         }
         
         public float computeMotionScale(Entity entity) {
@@ -54,21 +51,11 @@ public class PehkuiInterface {
         }
         
         public float computeMotionScale(Entity entity, float tickDelta) {
-            return computeMotionScale.apply(entity, tickDelta);
+            return 1.0f;
         }
     }
     
     public static Invoker invoker = new Invoker();
-    
-    public static BiFunction<Entity, Float, Float> getBaseScale = (e, d) -> 1.0f;
-    
-    public static BiConsumer<Entity, Float> setBaseScale = (e, s) -> { };
-    
-    public static BiFunction<Entity, Float, Float> computeThirdPersonScale = (e, d) -> 1.0f;
-    
-    public static BiFunction<Entity, Float, Float> computeBlockReachScale = (e, d) -> 1.0f;
-    
-    public static BiFunction<Entity, Float, Float> computeMotionScale = (e, d) -> 1.0f;
     
     private static boolean messageShown = false;
     

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/PehkuiInterface.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/PehkuiInterface.java
@@ -5,8 +5,10 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
 import net.minecraft.text.TranslatableText;
-import qouteall.imm_ptl.core.platform_specific.O_O;
 import qouteall.imm_ptl.core.portal.Portal;
+
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public class PehkuiInterface {
     
@@ -23,24 +25,55 @@ public class PehkuiInterface {
         
         }
         
-        public float getScale(Entity entity) {
-            return 1;
+        public float getBaseScale(Entity entity) {
+            return getBaseScale(entity, 1.0f);
         }
         
-        public float getMotionScale(Entity entity) {
-            return 1;
+        public float getBaseScale(Entity entity, float tickDelta) {
+            return getBaseScale.apply(entity, tickDelta);
+        }
+        
+        public void setBaseScale(Entity entity, float scale) {
+            setBaseScale.accept(entity, scale);
+        }
+        
+        public float computeThirdPersonScale(Entity entity, float tickDelta) {
+            return computeThirdPersonScale.apply(entity, tickDelta);
+        }
+        
+        public float computeBlockReachScale(Entity entity) {
+            return computeBlockReachScale(entity, 1.0f);
+        }
+        
+        public float computeBlockReachScale(Entity entity, float tickDelta) {
+            return computeBlockReachScale.apply(entity, tickDelta);
+        }
+        
+        public float computeMotionScale(Entity entity) {
+            return computeMotionScale(entity, 1.0f);
+        }
+        
+        public float computeMotionScale(Entity entity, float tickDelta) {
+            return computeMotionScale.apply(entity, tickDelta);
         }
     }
     
     public static Invoker invoker = new Invoker();
     
+    public static BiFunction<Entity, Float, Float> getBaseScale = (e, d) -> 1.0f;
+    
+    public static BiConsumer<Entity, Float> setBaseScale = (e, s) -> { };
+    
+    public static BiFunction<Entity, Float, Float> computeThirdPersonScale = (e, d) -> 1.0f;
+    
+    public static BiFunction<Entity, Float, Float> computeBlockReachScale = (e, d) -> 1.0f;
+    
+    public static BiFunction<Entity, Float, Float> computeMotionScale = (e, d) -> 1.0f;
+    
     private static boolean messageShown = false;
     
     @Environment(EnvType.CLIENT)
     private static void showMissingPehkui(Portal portal) {
-        if (O_O.isForge()) {
-            return;
-        }
         if (portal.hasScaling() && portal.teleportChangesScale) {
             if (!messageShown) {
                 messageShown = true;

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/block_manipulation/BlockManipulationServer.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/block_manipulation/BlockManipulationServer.java
@@ -67,7 +67,7 @@ public class BlockManipulationServer {
         ServerPlayerEntity player,
         BlockPos requestPos
     ) {
-        Float playerScale = PehkuiInterface.invoker.getScale(player);
+        Float playerScale = PehkuiInterface.invoker.computeBlockReachScale(player);
         
         Vec3d pos = Vec3d.ofCenter(requestPos);
         Vec3d playerPos = player.getPos();

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/PehkuiInterfaceInitializer.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/PehkuiInterfaceInitializer.java
@@ -9,16 +9,24 @@ import net.minecraft.text.LiteralText;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.Vec3d;
 import org.apache.commons.lang3.Validate;
-import qouteall.imm_ptl.core.CHelper;
 import qouteall.imm_ptl.core.IPGlobal;
 import qouteall.imm_ptl.core.McHelper;
 import qouteall.imm_ptl.core.PehkuiInterface;
 import qouteall.imm_ptl.core.ducks.IECamera;
 import qouteall.imm_ptl.core.portal.Portal;
+import virtuoel.pehkui.api.ScaleData;
+import virtuoel.pehkui.api.ScaleTypes;
 
 public class PehkuiInterfaceInitializer {
     
     public static class OnPehkuiPresent extends PehkuiInterface.Invoker {
+        
+        private boolean loggedGetBaseMessage = false;
+        private boolean loggedSetBaseMessage = false;
+        private boolean loggedComputeThirdPersonMessage = false;
+        private boolean loggedComputeBlockReachMessage = false;
+        private boolean loggedComputeMotionMessage = false;
+        
         @Override
         public boolean isPehkuiPresent() {
             return true;
@@ -32,6 +40,85 @@ public class PehkuiInterfaceInitializer {
         @Override
         public void onServerEntityTeleported(Entity entity, Portal portal) {
             onEntityTeleportedServer(entity, portal);
+        }
+        
+        private void logErrorMessage(Entity entity, Throwable e, String situation) {
+            e.printStackTrace();
+            entity.sendSystemMessage(
+                new LiteralText("Something went wrong with Pehkui (" + situation + ")"),
+                Util.NIL_UUID
+            );
+        }
+        
+        @Override
+        public float getBaseScale(Entity entity, float tickDelta) {
+            try {
+                return ScaleTypes.BASE.getScaleData(entity).getBaseScale(tickDelta);
+            }
+            catch (Throwable e) {
+                if (!loggedGetBaseMessage) {
+                    loggedGetBaseMessage = true;
+                    logErrorMessage(entity, e, "getting scale");
+                }
+                return super.getBaseScale(entity, tickDelta);
+            }
+        }
+        
+        @Override
+        public void setBaseScale(Entity entity, float scale) {
+            try {
+                final ScaleData data = ScaleTypes.BASE.getScaleData(entity);
+                data.setScale(scale);
+                data.setBaseScale(scale);
+            }
+            catch (Throwable e) {
+                if (!loggedSetBaseMessage) {
+                    loggedSetBaseMessage = true;
+                    logErrorMessage(entity, e, "setting scale");
+                }
+            }
+        }
+        
+        @Override
+        public float computeThirdPersonScale(Entity entity, float tickDelta) {
+            try {
+                return ScaleTypes.THIRD_PERSON.getScaleData(entity).getScale(tickDelta);
+            }
+            catch (Throwable e) {
+                if (!loggedComputeThirdPersonMessage) {
+                    loggedComputeThirdPersonMessage = true;
+                    logErrorMessage(entity, e, "getting third person scale");
+                }
+                return super.computeThirdPersonScale(entity, tickDelta);
+            }
+        }
+        
+        @Override
+        public float computeBlockReachScale(Entity entity, float tickDelta) {
+            try {
+                return ScaleTypes.BLOCK_REACH.getScaleData(entity).getScale(tickDelta);
+            }
+            catch (Throwable e) {
+                if (!loggedComputeBlockReachMessage) {
+                    loggedComputeBlockReachMessage = true;
+                    logErrorMessage(entity, e, "getting reach scale");
+                }
+                return super.computeBlockReachScale(entity, tickDelta);
+            }
+        }
+        
+        @Override
+        public float computeMotionScale(Entity entity, float tickDelta) {
+            try {
+                return ScaleTypes.MOTION.getScaleData(entity).getScale(tickDelta);
+            }
+            catch (Throwable e) {
+                if (!loggedComputeMotionMessage) {
+                    loggedComputeMotionMessage = true;
+                    logErrorMessage(entity, e, "getting motion scale");
+                }
+                return super.computeMotionScale(entity, tickDelta);
+            }
         }
     }
     
@@ -72,24 +159,18 @@ public class PehkuiInterfaceInitializer {
         Vec3d eyePos = McHelper.getEyePos(entity);
         Vec3d lastTickEyePos = McHelper.getLastTickEyePos(entity);
         
-        try {
-            float oldScale = PehkuiInterface.invoker.getBaseScale(entity);
-            float newScale = transformScale(portal, oldScale);
-            
-            if (!entity.world.isClient && isScaleIllegal(newScale)) {
-                newScale = 1;
-                entity.sendSystemMessage(
-                    new LiteralText("Scale out of range"),
-                    Util.NIL_UUID
-                );
-            }
-            
-            PehkuiInterface.invoker.setBaseScale(entity, newScale);
+        float oldScale = PehkuiInterface.invoker.getBaseScale(entity);
+        float newScale = transformScale(portal, oldScale);
+        
+        if (!entity.world.isClient && isScaleIllegal(newScale)) {
+            newScale = 1;
+            entity.sendSystemMessage(
+                new LiteralText("Scale out of range"),
+                Util.NIL_UUID
+            );
         }
-        catch (Throwable e) {
-            e.printStackTrace();
-            CHelper.printChat("Something went wrong with Pehkui");
-        }
+        
+        PehkuiInterface.invoker.setBaseScale(entity, newScale);
         
         if (!entity.world.isClient) {
             IPGlobal.serverTaskList.addTask(() -> {

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/render/CrossPortalViewRendering.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/render/CrossPortalViewRendering.java
@@ -93,7 +93,7 @@ public class CrossPortalViewRendering {
             ClientWorldLoader.getWorld(portal.dimensionTo),
             renderingCameraPos, portal.getAdditionalCameraTransformation(),
             false, null,
-            MinecraftClient.getInstance().options.viewDistance,
+            client.options.viewDistance,
             ((IEGameRenderer) client.gameRenderer).getDoRenderHand()
         );
         
@@ -136,7 +136,7 @@ public class CrossPortalViewRendering {
     }
     
     private static double getThirdPersonMaxDistance() {
-        return 4.0d * PehkuiInterface.invoker.getScale(MinecraftClient.getInstance().player);
+        return 4.0d * PehkuiInterface.invoker.computeThirdPersonScale(client.player, client.getTickDelta());
     }
     
     //    private static Vec3d getThirdPersonCameraPos(Portal portalHit, Camera resuableCamera) {


### PR DESCRIPTION
Adds third person and block reach scale getters to `PehkuiInvoker` which use the methods that take the `tickDelta` and scale modifiers into account instead of using the base scale.

Moves try catch blocks closer to Pehkui calls.

Cleans up some duplicated code in the client/server side scaling methods.