### PR TITLE
Update mod compatibility for 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,10 +99,10 @@ allprojects {
 
         modCompileOnly('com.github.Virtuoel:Pehkui:fabric~1.14.4-1.x.x-SNAPSHOT')
 
-        modCompileOnly "maven.modrinth:sodium:mc1.18.1-0.4.0-alpha6"
+        modCompileOnly "maven.modrinth:sodium:mc1.18.2-0.4.1"
 //        implementation "org.joml:joml:1.10.2" // for sodium
 
-        modCompileOnly 'maven.modrinth:iris:1.18.x-v1.2.0'
+        modCompileOnly 'maven.modrinth:iris:1.18.x-v1.2.1'
 //        implementation "org.anarres:jcpp:1.4.14" // for iris
 //        implementation 'org.slf4j:slf4j-api:1.7.12' // for iris
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,8 +43,8 @@
     "optifabric": "*",
     "pehkui": "<3.0.0",
     "sodium": [
-      ">0.4.0-alpha6",
-      "<0.4.0-alpha6"
+      ">0.4.1+build.15",
+      "<0.4.1+build.15"
     ],
     "viafabric-mc118": "*",
     "resolutioncontrol": "*",


### PR DESCRIPTION
Allows newer versions of sodium/iris for 1.18.2 to work with this mod.