### PR TITLE
Fix #71 with null check

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/render/optimization/SharedBlockMeshBuffers.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/render/optimization/SharedBlockMeshBuffers.java
@@ -1,19 +1,16 @@
 package qouteall.imm_ptl.core.render.optimization;
 
 import com.google.common.collect.Queues;
-import net.minecraft.client.renderer.chunk.ChunkRenderDispatcher;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ChunkBufferBuilderPack;
+import net.minecraft.client.renderer.RenderType;
 import org.apache.commons.lang3.Validate;
 import qouteall.imm_ptl.core.CHelper;
 import qouteall.imm_ptl.core.IPGlobal;
 import qouteall.q_misc_util.Helper;
 
 import java.util.ArrayList;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.ChunkBufferBuilderPack;
-import net.minecraft.client.renderer.RenderType;
 
 /**
  * This optimization makes that different dimensions of ChunkRenderDispatcher
@@ -96,7 +93,7 @@ public class SharedBlockMeshBuffers {
     }
     
     public static String getDebugString() {
-        if (IPGlobal.enableSharedBlockMeshBuffers) {
+        if (IPGlobal.enableSharedBlockMeshBuffers && threadBuffers != null) {
             return "SharedBlockMeshBuffers " + Integer.toString(threadBuffers.size());
         }
         return "";


### PR DESCRIPTION
Fixes a debug screen error that prevents the F3 screen from working in some situations.  This appears to be the error noted in issue #71.

Did a quick edit in the github editor, so I'm not sure why there is more than just the one line of changes