### PR TITLE
Add melius-vanish compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,7 @@ allprojects {
         modImplementation "maven.modrinth:starlight:1.1.1+1.19"
 
         modCompileOnly 'maven.modrinth:iris:1.6.3+1.19.4'
+        modCompileOnly 'maven.modrinth:vanish:1.4.0+1.19.4'
 //        implementation "org.anarres:jcpp:1.4.14" // for iris
 //        implementation 'io.github.douira:glsl-transformer:2.0.0-pre13' // for iris
 //        implementation 'org.antlr:antlr4-runtime:4.11.1' // for iris

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/IPVanishCompat.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/compat/IPVanishCompat.java
@@ -1,0 +1,29 @@
+package qouteall.imm_ptl.core.compat;
+
+import me.drex.vanish.api.VanishAPI;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import qouteall.q_misc_util.Helper;
+
+import javax.annotation.Nullable;
+
+public class IPVanishCompat {
+    
+    public static boolean isVanishPresent = false;
+    
+    public static void init(){
+        if (FabricLoader.getInstance().isModLoaded("melius-vanish")) {
+            isVanishPresent = true;
+            Helper.log("Vanish is present");
+        }
+    }
+
+    public static boolean canSeePlayer(@Nullable Player executive, ServerPlayer viewer) {
+        if (isVanishPresent && executive instanceof ServerPlayer executiveServer) {
+            return VanishAPI.canSeePlayer(executiveServer, viewer);
+        }
+        return true;
+    }
+    
+}

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/other_sync/MixinPlayerList.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/other_sync/MixinPlayerList.java
@@ -22,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import qouteall.imm_ptl.core.IPGlobal;
 import qouteall.imm_ptl.core.chunk_loading.NewChunkTrackingGraph;
+import qouteall.imm_ptl.core.compat.IPVanishCompat;
 import qouteall.imm_ptl.core.network.PacketRedirection;
 import qouteall.imm_ptl.core.portal.global_portals.GlobalPortalStorage;
 
@@ -38,7 +39,7 @@ public class MixinPlayerList {
     @Shadow
     @Final
     private MinecraftServer server;
-    
+
     @Inject(method = "Lnet/minecraft/server/players/PlayerList;sendLevelInfo(Lnet/minecraft/server/level/ServerPlayer;Lnet/minecraft/server/level/ServerLevel;)V", at = @At("RETURN"))
     private void onSendWorldInfo(ServerPlayer player, ServerLevel world, CallbackInfo ci) {
         if (!IPGlobal.serverTeleportationManager.isFiringMyChangeDimensionEvent) {
@@ -106,7 +107,7 @@ public class MixinPlayerList {
             dimension, chunkPos.x, chunkPos.z
         ).filter(playerEntity -> NewChunkTrackingGraph.isPlayerWatchingChunkWithinRaidus(
             playerEntity, dimension, chunkPos.x, chunkPos.z, (int) distance + 16
-        )).forEach(playerEntity -> {
+        ) && IPVanishCompat.canSeePlayer(excludingPlayer, playerEntity)).forEach(playerEntity -> {
             if (playerEntity != excludingPlayer) {
                 PacketRedirection.sendRedirectedMessage(
                     playerEntity, dimension, packet

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/IPModEntry.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/platform_specific/IPModEntry.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import qouteall.imm_ptl.core.IPModMain;
 import qouteall.imm_ptl.core.compat.GravityChangerInterface;
+import qouteall.imm_ptl.core.compat.IPVanishCompat;
 import qouteall.q_misc_util.Helper;
 
 public class IPModEntry implements ModInitializer {
@@ -17,6 +18,7 @@ public class IPModEntry implements ModInitializer {
     public void onInitialize() {
         IPModMain.init();
         RequiemCompat.init();
+        IPVanishCompat.init();
         
         IPRegistry.registerEntitiesFabric();
         


### PR DESCRIPTION
This PR fixes a mod compatibility with `melius-vanish`.
[I have recently received an issue for this](https://github.com/DrexHD/Vanish/issues/13) on my repository. After looking into this, the issue turned out to be that: Immersive Portals [`@Overwrite`s this method](https://github.com/iPortalTeam/ImmersivePortalsMod/blob/1.19.4/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/other_sync/MixinPlayerList.java#L92-L116), which [melius-vanish attempts to modify](https://github.com/DrexHD/Vanish/blob/1.19.4/stable/src/main/java/me/drex/vanish/mixin/compat/not_imm_ptl_core/PlayerListMixin.java#L16-L29), to hide sound events from vanished players.
I have now released a version of my mod, which doesn't load the conflicting mixin if `imm_ptl_ore` is present.
This PR re-implements the missing feature using my mods API.