### PR TITLE
[1.20.4] Fixed server crash on startup

### DIFF
--- a/src/main/java/qouteall/q_misc_util/dimension/DimensionIntId.java
+++ b/src/main/java/qouteall/q_misc_util/dimension/DimensionIntId.java
@@ -3,6 +3,7 @@ package qouteall.q_misc_util.dimension;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -27,10 +28,12 @@ public class DimensionIntId {
         DimensionAPI.SERVER_DIMENSION_DYNAMIC_UPDATE_EVENT.register(
             (server, dimensions) -> onServerDimensionChanged(server)
         );
-        
-        IPCGlobal.CLIENT_EXIT_EVENT.register(() -> {
-            clientRecord = null;
-        });
+
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT){
+            IPCGlobal.CLIENT_EXIT_EVENT.register(() -> {
+                clientRecord = null;
+            });
+        }
     }
     
     @Environment(EnvType.CLIENT)


### PR DESCRIPTION
Added a check for calling client-only method in `DimensionIntId` class.

It crashes because there is no such class as `qouteall.imm_ptl.core.IPCGlobal` for server. Without the check server would crash with following stacktrace:

```
[13:20:46] [main/ERROR] (Minecraft) Failed to start the minecraft server
java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'immersive_portals'!
        at net.fabricmc.loader.impl.FabricLoaderImpl.lambda$invokeEntrypoints$2(FabricLoaderImpl.java:388) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:386) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.Hooks.startServer(Hooks.java:63) ~[fabric-loader-0.15.1.jar:?]
        at net.minecraft.server.Main.main(Main.java:115) ~[minecraft-merged-0a1ae17efa-1.20.4-loom.mappings.1_20_4.layered+hash.435796289-v2.jar:?]
        at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:470) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.devlaunchinjector.Main.main(Main.java:86) ~[dev-launch-injector-0.2.1+build.8.jar:?]
Caused by: java.lang.RuntimeException: Cannot load class qouteall.imm_ptl.core.IPCGlobal in environment type SERVER
        at net.fabricmc.loader.impl.transformer.FabricTransformer.transform(FabricTransformer.java:59) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getPreMixinClassByteArray(KnotClassDelegate.java:462) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getPostMixinClassByteArray(KnotClassDelegate.java:415) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.tryLoadClass(KnotClassDelegate.java:323) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.loadClass(KnotClassDelegate.java:218) ~[fabric-loader-0.15.1.jar:?]
        at net.fabricmc.loader.impl.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:119) ~[fabric-loader-0.15.1.jar:?]
        at java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
        at qouteall.q_misc_util.dimension.DimensionIntId.init(DimensionIntId.java:33) ~[main/:?]
        at qouteall.q_misc_util.MiscUtilModEntry.onInitialize(MiscUtilModEntry.java:14) ~[main/:?]
        at net.fabricmc.loader.impl.FabricLoaderImpl.invokeEntrypoints(FabricLoaderImpl.java:384) ~[fabric-loader-0.15.1.jar:?]
        ... 6 more
```

btw, the commit should say 'add check for accessing a client-only class' :\