### PR TITLE
made overwrite an inject cancelled mixin

### DIFF
--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkMap_C.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkMap_C.java
@@ -81,15 +81,10 @@ public abstract class MixinChunkMap_C implements IEThreadedAnvilChunkStorage {
         return getVisibleChunkIfPresent(long_1);
     }
     
-    /**
-     * @author qouteall
-     * @reason make mod incompatibility fail fast
-     * Actually handled in {@link qouteall.imm_ptl.core.chunk_loading.ChunkDataSyncManager}
-     */
-    @Overwrite
-    private void playerLoadedChunk(
-        ServerPlayer player, MutableObject<ClientboundLevelChunkWithLightPacket> cachedDataPacket, LevelChunk chunk
-    ) {
+    //change horrible overwrite to more compatible inject mixin
+    @Inject (method = "playerLoadedChunk", at = @At("HEAD"), cancellable = true)
+    private void playerLoadedChunk(ServerPlayer player, MutableObject<ClientboundLevelChunkWithLightPacket> packetCache, LevelChunk chunk, CallbackInfo ci) {
+        ci.cancel();
         //chunk data packets will be sent on ChunkDataSyncManager
     }
     


### PR DESCRIPTION
This removes a fast fail overwrite mixin that fails when the method becomes public, changing it to an injected cancelled at-head mixin keeps the same functionality but makes it to were if the original method becomes public it won't crash due to an overwrite fail

basically tldr fixes this bug.

`[16:50:57] [Worker-ResourceReload-9/FATAL] [mixin/]: Mixin apply for mod imm_ptl_core failed imm_ptl.mixins.json:common.chunk_sync.MixinChunkMap_C from mod imm_ptl_core -> net.minecraft.server.level.ChunkMap: org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException PRIVATE @Overwrite method m_183760_ in imm_ptl.mixins.json:common.chunk_sync.MixinChunkMap_C from mod imm_ptl_core cannot reduce visibiliy of PUBLIC target method`