### PR TITLE
Corrected positioning of GUI portal rendering

### DIFF
--- a/src/main/java/qouteall/imm_ptl/core/api/example/ExampleGuiPortalRendering.java
+++ b/src/main/java/qouteall/imm_ptl/core/api/example/ExampleGuiPortalRendering.java
@@ -185,12 +185,12 @@ public class ExampleGuiPortalRendering {
             // Draw the framebuffer
             int h = minecraft.getWindow().getHeight();
             int w = minecraft.getWindow().getWidth();
-            MyRenderHelper.drawFramebuffer(
+            MyRenderHelper.drawFramebufferWithBounds(
                 frameBuffer,
                 true, // enable alpha blend
                 false, // don't modify alpha
-                w * 0.2f, w * 0.8f,
-                h * 0.2f, h * 0.8f
+                (int) (w * 0.2f), (int) (w * 0.8f),
+                (int) (h * 0.2f), (int) (h * 0.8f)
             );
             
             guiGraphics.drawCenteredString(

--- a/src/main/java/qouteall/imm_ptl/core/render/MyRenderHelper.java
+++ b/src/main/java/qouteall/imm_ptl/core/render/MyRenderHelper.java
@@ -16,6 +16,7 @@ import net.minecraft.client.renderer.chunk.SectionRenderDispatcher;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceProvider;
+import net.minecraft.util.Mth;
 import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.Validate;
 import org.joml.Matrix4f;
@@ -271,31 +272,29 @@ public class MyRenderHelper {
         boolean doUseAlphaBlend,
         boolean doEnableModifyAlpha
     ) {
-        float right = (float) textureProvider.viewWidth;
-        float up = (float) textureProvider.viewHeight;
-        float left = 0;
-        float bottom = 0;
+        int x = 0;
+        int y = 0;
         
         int viewportWidth = textureProvider.viewWidth;
         int viewportHeight = textureProvider.viewHeight;
         
-        drawFramebufferWithViewport(
+        drawFramebufferWithCoordinatesAndDimensions(
             textureProvider, doUseAlphaBlend, doEnableModifyAlpha,
-            left, right, bottom, up,
-            viewportWidth, viewportHeight
+            x, y, viewportWidth, viewportHeight
         );
     }
     
-    public static void drawFramebuffer(
+    public static void drawFramebufferWithBounds(
         RenderTarget textureProvider, boolean doUseAlphaBlend, boolean doEnableModifyAlpha,
-        float xMin, float xMax, float yMin, float yMax
+        int xMin, int xMax, int yMin, int yMax
     ) {
-        drawFramebufferWithViewport(
+
+        drawFramebufferWithCoordinatesAndDimensions(
             textureProvider,
             doUseAlphaBlend, doEnableModifyAlpha,
-            xMin, xMax, yMin, yMax,
-            client.getWindow().getWidth(),
-            client.getWindow().getHeight()
+            xMin, yMin,
+            Mth.abs(xMax - xMin),
+            Mth.abs(yMax - yMin)
         );
     }
     
@@ -303,16 +302,15 @@ public class MyRenderHelper {
      * {@link RenderTarget#blitToScreen(int, int)}
      */
     @IPVanillaCopy
-    public static void drawFramebufferWithViewport(
+    public static void drawFramebufferWithCoordinatesAndDimensions(
         RenderTarget textureProvider, boolean doUseAlphaBlend, boolean doEnableModifyAlpha,
-        float left, float right, float bottom, float up,
-        int viewportWidth, int viewportHeight
+        int x, int y, int viewportWidth, int viewportHeight
     ) {
         CHelper.checkGlError();
-        
-        GlStateManager._disableDepthTest();
-        GlStateManager._depthMask(false);
-        GlStateManager._viewport(0, 0, viewportWidth, viewportHeight);
+
+        RenderSystem.disableDepthTest();
+        RenderSystem.depthMask(false);
+        RenderSystem.viewport(x, textureProvider.viewHeight - viewportHeight - y, viewportWidth, viewportHeight);
         
         if (doUseAlphaBlend) {
             RenderSystem.enableBlend();
@@ -336,10 +334,10 @@ public class MyRenderHelper {
         }
         
         if (doEnableModifyAlpha) {
-            GlStateManager._colorMask(true, true, true, true);
+            RenderSystem.colorMask(true, true, true, true);
         }
         else {
-            GlStateManager._colorMask(true, true, true, false);
+            RenderSystem.colorMask(true, true, true, false);
         }
         
         ShaderInstance shader = doUseAlphaBlend ?
@@ -356,9 +354,9 @@ public class MyRenderHelper {
         bufferBuilder.addVertex(0.0f, 1.0f, 0.0f);
         BufferUploader.draw(bufferBuilder.buildOrThrow());
         shader.clear();
-        
-        GlStateManager._depthMask(true);
-        GlStateManager._colorMask(true, true, true, true);
+
+        RenderSystem.depthMask(true);
+        RenderSystem.colorMask(true, true, true, true);
         
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();

--- a/src/main/java/qouteall/imm_ptl/core/render/MyRenderHelper.java
+++ b/src/main/java/qouteall/imm_ptl/core/render/MyRenderHelper.java
@@ -283,6 +283,32 @@ public class MyRenderHelper {
             x, y, viewportWidth, viewportHeight
         );
     }
+
+    public static void drawFramebuffer(
+            RenderTarget textureProvider, boolean doUseAlphaBlend, boolean doEnableModifyAlpha,
+            float xMin, float xMax, float yMin, float yMax
+    ) {
+        drawFramebufferWithCoordinatesAndDimensions(
+                textureProvider,
+                doUseAlphaBlend, doEnableModifyAlpha,
+                0, 0,
+                client.getWindow().getWidth(),
+                client.getWindow().getHeight()
+        );
+    }
+
+    public static void drawFramebufferWithViewport(
+            RenderTarget textureProvider, boolean doUseAlphaBlend, boolean doEnableModifyAlpha,
+            float left, float right, float bottom, float up,
+            int viewportWidth, int viewportHeight
+    ) {
+        drawFramebufferWithCoordinatesAndDimensions(
+                textureProvider,
+                doUseAlphaBlend, doEnableModifyAlpha,
+                0, 0,
+                viewportWidth, viewportHeight
+        );
+    }
     
     public static void drawFramebufferWithBounds(
         RenderTarget textureProvider, boolean doUseAlphaBlend, boolean doEnableModifyAlpha,


### PR DESCRIPTION
The current MyRenderHelper#drawFramebufferWithViewport does not allow the viewport to be positioned, meaning all GUI portals render in the bottom-left corner. This pull request solves that problem, allowing the user to choose a method that mimics the current way (with left, top, right, and bottom bounds) and the new way (with an x,y coordinate and width and height).

Also replaced GlStateManager calls to RenderSystem as a best practice.