### PR TITLE
Fix ChunkMap#getPlayers returning an empty list of players

### DIFF
--- a/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkHolder.java
+++ b/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkHolder.java
@@ -40,24 +40,5 @@ public class MixinChunkHolder implements IEChunkHolder {
             ((Packet) packet)
         );
     }
-    
-    /**
-     * Does not mixin {@link net.minecraft.server.level.ChunkMap#getPlayers(ChunkPos, boolean)}
-     * because the current chunk map tracking implementation should coexist with vanilla tracking
-     * and avoid deeply interfering with vanilla chunk tracking.
-     */
-    @Redirect(
-        method = "broadcastChanges",
-        at = @At(
-            value = "INVOKE",
-            target = "Lnet/minecraft/server/level/ChunkHolder$PlayerProvider;getPlayers(Lnet/minecraft/world/level/ChunkPos;Z)Ljava/util/List;"
-        )
-    )
-    private List<ServerPlayer> redirectGetPlayers(ChunkHolder.PlayerProvider playerProvider, ChunkPos chunkPos, boolean boundaryOnly) {
-        return ImmPtlChunkTracking.getPlayersViewingChunk(
-            ((Level) levelHeightAccessor).dimension(),
-            chunkPos.x, chunkPos.z,
-            boundaryOnly
-        );
-    }
+
 }

--- a/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkMap_C.java
+++ b/src/main/java/qouteall/imm_ptl/core/mixin/common/chunk_sync/MixinChunkMap_C.java
@@ -6,6 +6,7 @@ import net.minecraft.server.level.ChunkTrackingView;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.ThreadedLevelLightEngine;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,9 +15,12 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import qouteall.imm_ptl.core.chunk_loading.ImmPtlChunkTracking;
 import qouteall.imm_ptl.core.chunk_loading.PlayerChunkLoading;
 import qouteall.imm_ptl.core.ducks.IEChunkMap;
+
+import java.util.List;
 
 @Mixin(value = ChunkMap.class, priority = 1100)
 public abstract class MixinChunkMap_C implements IEChunkMap {
@@ -68,7 +72,16 @@ public abstract class MixinChunkMap_C implements IEChunkMap {
     ) {
         ci.cancel();
     }
-    
+
+    @Inject(
+        method = "getPlayers",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    public void getPlayers(ChunkPos pos, boolean boundaryOnly, CallbackInfoReturnable<List<ServerPlayer>> cir) {
+        cir.setReturnValue(ImmPtlChunkTracking.getPlayersViewingChunk(this.level.dimension(), pos.x, pos.z, boundaryOnly));
+    }
+
     /**
      * @author qouteall
      * @reason


### PR DESCRIPTION
MixinChunkMap_C cancels applyChunkTrackingView, causing ChunkMap#getPlayers to return an empty list.

According to a javadoc comment in MixinChunkHolder, this behaviour seems unintentional.

This mixin overrides ChunkMap#getPlayers to return the correct list of viewers using ImmPtlChunkTracking.
I have also removed the MixinChunkHolder redirect of ChunkMap#getPlayers, since it should now be correctly returned by the base method.

This fixes https://github.com/iPortalTeam/ImmersivePortalsMod/issues/1542, and probably many other compatibility issues with mods that rely on ChunkMap#getPlayers.