### PR TITLE
Allow Gravity Changer to work on 1.21.1

### DIFF
--- a/src/main/java/qouteall/imm_ptl/core/platform_specific/IPModEntry.java
+++ b/src/main/java/qouteall/imm_ptl/core/platform_specific/IPModEntry.java
@@ -29,7 +29,7 @@ public class IPModEntry implements ModInitializer {
             Helper.log("Dimensional Threading is not present");
         }
         
-        if (FabricLoader.getInstance().isModLoaded("gravity_changer_q")) {
+        if (FabricLoader.getInstance().isModLoaded("gravity_changer")) {
             GravityChangerInterface.invoker = new GravityChangerInterface.OnGravityChangerPresent();
             Helper.log("Gravity API is present");
         }


### PR DESCRIPTION
If you change the mod id for gravity changer, it would allow for changing gravity with [this](https://modrinth.com/mod/gravity-changer-unofficial-port) fork of the gravity mod.