### PR TITLE
Fix crash with Valkyrien Skies 2.4.11 [1.20.1]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
 
-    id 'fabric-loom' version '1.6-SNAPSHOT' apply(false)
+    id 'fabric-loom' version '1.13-SNAPSHOT' apply(false)
     // uses qouteall's fork of fabric loom, see settings.gradle
 
     id 'maven-publish'
@@ -108,9 +108,6 @@ allprojects {
         modCompileOnly("com.github.qouteall:GravityChanger:${gravity_changer_version}") {
             exclude(group: "net.fabricmc.fabric-api")
         }
-
-        implementation("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixin_extras_version}")
-        annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixin_extras_version}")
     }
 
     processResources {
@@ -177,8 +174,6 @@ publishing {
 
 dependencies {
     include "me.shedaniel.cloth:cloth-config-fabric:${cloth_config_version}"
-
-    include("com.github.llamalad7.mixinextras:mixinextras-fabric:${mixin_extras_version}")
 
     modLocalRuntime "maven.modrinth:modmenu:${modmenu_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ archives_base_name=immersive-portals
 
 modmenu_version=7.0.1
 cloth_config_version=11.0.99
-mixin_extras_version=0.2.0-beta.9
 sodium_path=maven.modrinth:sodium:mc1.20.1-0.5.13-fabric
 iris_path=maven.modrinth:iris:1.7.6+1.20.1
 gravity_changer_version=v1.1.1-mc1.20.1
@@ -24,7 +23,7 @@ enable_geckolib=false
 
 minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.10
-loader_version=0.14.22
+loader_version=0.18.6
 
 #Fabric api
 fabric_version=0.88.1+1.20.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinFrustum_FixDeadLoop.java
+++ b/imm_ptl_core/src/main/java/qouteall/imm_ptl/core/mixin/client/render/MixinFrustum_FixDeadLoop.java
@@ -1,71 +1,55 @@
 package qouteall.imm_ptl.core.mixin.client.render;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import net.minecraft.client.renderer.culling.Frustum;
-import org.joml.FrustumIntersection;
-import org.joml.Vector4f;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
-import qouteall.imm_ptl.core.miscellaneous.IPVanillaCopy;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import qouteall.imm_ptl.core.render.TransformationManager;
 import qouteall.q_misc_util.Helper;
 import qouteall.q_misc_util.my_util.LimitedLogger;
 
 @Mixin(Frustum.class)
 public abstract class MixinFrustum_FixDeadLoop {
-    @Shadow
-    private double camX;
-    
-    @Shadow
-    private double camY;
-    
-    @Shadow
-    private double camZ;
-    
-    @Shadow
-    private Vector4f viewVector;
-    
-    @Shadow @Final private FrustumIntersection intersection;
-    private static LimitedLogger limitedLogger = new LimitedLogger(10);
-    
+
+    @Unique
+    private static final LimitedLogger limitedLogger = new LimitedLogger(10);
+
     /**
      * Make it to not deadloop when using isometric view.
-     * Also make it to not deadloop even if the projection matrix is broken. (In normal cases the projection should not be broken.)
-     *
-     * @author qouteall
-     * @reason Hard to do by injection or redirection
      */
-    @Overwrite
-    @IPVanillaCopy
-    public Frustum offsetToFullyIncludeCameraCube(int gridSize) {
+    @Inject(method = "offsetToFullyIncludeCameraCube", at = @At("HEAD"), cancellable = true)
+    public void initButSkipIfIsometric(int i, CallbackInfoReturnable<Frustum> cir, @Share("countLimit") LocalIntRef countLimit) {
         if (TransformationManager.isIsometricView) {
-            return (Frustum) (Object) this;
+            cir.setReturnValue((Frustum) (Object) this);
         }
-        
-        double minX = Math.floor(this.camX / (double) gridSize) * (double) gridSize;
-        double minY = Math.floor(this.camY / (double) gridSize) * (double) gridSize;
-        double minZ = Math.floor(this.camZ / (double) gridSize) * (double) gridSize;
-        double maxX = Math.ceil(this.camX / (double) gridSize) * (double) gridSize;
-        double maxY = Math.ceil(this.camY / (double) gridSize) * (double) gridSize;
-        double maxZ = Math.ceil(this.camZ / (double) gridSize) * (double) gridSize;
-        
-        int countLimit = 10; // limit the loop count
-        
-        while (this.intersection.intersectAab((float) (minX - this.camX), (float) (minY - this.camY), (float) (minZ - this.camZ), (float) (maxX - this.camX), (float) (maxY - this.camY), (float) (maxZ - this.camZ))!= -2) {
-            this.camX -= (double) (this.viewVector.x() * 4.0F);
-            this.camY -= (double) (this.viewVector.y() * 4.0F);
-            this.camZ -= (double) (this.viewVector.z() * 4.0F);
-            countLimit--;
-            if (countLimit <= 0) {
-                limitedLogger.invoke(() -> {
-                    Helper.err("the projection matrix and the frustum are abnormal");
-                    new Throwable().printStackTrace();
-                });
-                break;
-            }
+        countLimit.set(10+1);
+    }
+
+    /**
+     * Also make it to not deadloop even if the projection matrix is broken. (In normal cases the projection should not be broken.)
+     */
+    @Definition(id = "intersectAab", method = "Lorg/joml/FrustumIntersection;intersectAab(FFFFFF)I")
+    @Expression("?.intersectAab(?, ?, ?, ?, ?, ?) != ?")
+    @ModifyExpressionValue(
+            method = "offsetToFullyIncludeCameraCube",
+            at = @At("MIXINEXTRAS:EXPRESSION")
+    )
+    public boolean decrementFrustumLoopCount(boolean shouldContinue, @Share("countLimit") LocalIntRef countLimit) {
+        countLimit.set(countLimit.get()-1);
+        if (countLimit.get() <= 0) {
+            limitedLogger.invoke(() -> {
+                Helper.err("the projection matrix and the frustum are abnormal");
+                new Throwable().printStackTrace();
+            });
+            return false;
         }
-        
-        return (Frustum) (Object) this;
+        return shouldContinue;
     }
 }

--- a/imm_ptl_core/src/main/resources/fabric.mod.json
+++ b/imm_ptl_core/src/main/resources/fabric.mod.json
@@ -19,9 +19,6 @@
   "icon": "assets/immersive_portals/icon.png",
   "environment": "*",
   "entrypoints": {
-    "preLaunch": [
-      "com.llamalad7.mixinextras.MixinExtrasBootstrap::init"
-    ],
     "main": [
       "qouteall.imm_ptl.core.platform_specific.IPModEntry"
     ],

--- a/imm_ptl_core/src/main/resources/fabric.mod.json
+++ b/imm_ptl_core/src/main/resources/fabric.mod.json
@@ -38,7 +38,7 @@
     "imm_ptl_compat.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.7.4",
+    "fabricloader": ">=0.17.0",
     "fabric": ">=0.28.1"
   },
   "breaks": {

--- a/imm_ptl_core/src/main/resources/imm_ptl.mixins.json
+++ b/imm_ptl_core/src/main/resources/imm_ptl.mixins.json
@@ -128,5 +128,8 @@
   ],
   "injectors": {
     "defaultRequire": 1
+  },
+  "mixinextras": {
+    "minVersion": "0.5.0"
   }
 }


### PR DESCRIPTION
The latest version of Valkyrien Skies [adds a mixin into `Frustum::offsetToFullyIncludeCameraCube`](https://github.com/ValkyrienSkies/Valkyrien-Skies-2/blob/1.20.1/main/common/src/main/java/org/valkyrienskies/mod/mixin/feature/fix_frustum_dead_loop/MixinFrustum.java#L18).

This presents a problem since there is an `@Overwrite` mixin on that method in Immersive Portals 5.2.0. That's why I made this pull request to rewrite it in a more compatible way.

I also noticed that Immersive Portals was still bundling an old version of MixinExtras for some reason, so I got rid of that and set the dev environment to use the a more recent version of loom and Fabric Loader. I also set the minimum reqiured version of Fabric Loader in fabric.mod.json to 0.17 since that was the first version of Fabric Loader to bundle MixinExtras version 0.5.0.